### PR TITLE
[SimpleWallet] Add missing linefeed in transfer status message.

### DIFF
--- a/src/SimpleWallet/Transfer.cpp
+++ b/src/SimpleWallet/Transfer.cpp
@@ -847,6 +847,7 @@ void doTransfer(uint16_t mixin, std::string address, uint64_t amount,
                     = walletInfo->wallet.getTransaction(id);
 
                 std::cout << SuccessMsg("Transaction has been sent!")
+                          << std::endl
                           << SuccessMsg("Hash: " + 
                                         Common::podToHex(tx.hash))
                           << std::endl;


### PR DESCRIPTION
Two other instances of same status message in this file split it as two lines. Make it consistent by splitting the third instance as two lines too.