### PR TITLE
[SimpleWallet] Fix wrong address prefix.

### DIFF
--- a/src/SimpleWallet/SimpleWallet.cpp
+++ b/src/SimpleWallet/SimpleWallet.cpp
@@ -283,7 +283,7 @@ std::shared_ptr<WalletInfo> createViewWallet(CryptoNote::WalletGreen &wallet)
         else if (address.substr(0, 2) != "P6")
         {
             std::cout << WarningMsg("Invalid address! It should start with "
-                                    "\"PSTAR\"!") << std::endl;
+                                    "\"P6\"!") << std::endl;
         }
         else if (!CryptoNote::parseAccountAddressString(prefix, publicKeys,
                                                         address))

--- a/src/SimpleWallet/Transfer.cpp
+++ b/src/SimpleWallet/Transfer.cpp
@@ -1172,11 +1172,11 @@ bool parseAddress(std::string address)
         return false;
     }
     /* Can't see an easy way to go from prefix num -> prefix string, so for
-       now just hard code "PSTAR" - it will let testers send stuff at least */
+       now just hard code "P6" - it will let testers send stuff at least */
     else if (prefix != expectedPrefix)
     {
         std::cout << WarningMsg("Invalid address! It should start with "
-                                "\"PSTAR\"!") << std::endl << std::endl;
+                                "\"P6\"!") << std::endl << std::endl;
 
         return false;
     }


### PR DESCRIPTION
PSTAR has address prefix of "P6", not "PSTAR".