### PR TITLE
[Core/Rpc/Daemon] Add printing information about alternate chains.

### DIFF
--- a/src/CryptoNoteCore/BlockchainCache.cpp
+++ b/src/CryptoNoteCore/BlockchainCache.cpp
@@ -897,6 +897,11 @@ uint32_t BlockchainCache::getTopBlockIndex() const {
   return startIndex + static_cast<uint32_t>(blockInfos.size()) - 1;
 }
 
+const Crypto::Hash& BlockchainCache::getStartBlockHash() const {
+  assert(!blockInfos.empty());
+  return blockInfos.get<BlockIndexTag>().front().blockHash;
+}
+
 const Crypto::Hash& BlockchainCache::getTopBlockHash() const {
   assert(!blockInfos.empty());
   return blockInfos.get<BlockIndexTag>().back().blockHash;

--- a/src/CryptoNoteCore/BlockchainCache.h
+++ b/src/CryptoNoteCore/BlockchainCache.h
@@ -119,6 +119,7 @@ public:
   ExtractOutputKeysResult extractKeyOtputReferences(uint64_t amount, Common::ArrayView<uint32_t> globalIndexes, std::vector<std::pair<Crypto::Hash, size_t>>& outputReferences) const override;
 
   uint32_t getTopBlockIndex() const override;
+  const Crypto::Hash& getStartBlockHash() const override;
   const Crypto::Hash& getTopBlockHash() const override;
   uint32_t getBlockCount() const override;
   bool hasBlock(const Crypto::Hash& blockHash) const override;

--- a/src/CryptoNoteCore/Core.cpp
+++ b/src/CryptoNoteCore/Core.cpp
@@ -1158,6 +1158,14 @@ size_t Core::getBlockchainTransactionCount() const {
   return mainChain->getTransactionCount();
 }
 
+altChainList Core::getAlternateChains() const {
+  altChainList altList;
+  for (size_t i = 1; i < chainsLeaves.size(); i++) {
+    altList.push_back({ chainsLeaves[i], chainsLeaves[i]->getBlockCount() });
+  }
+  return altList;
+}
+
 size_t Core::getAlternativeBlockCount() const {
   throwIfNotInitialized();
 

--- a/src/CryptoNoteCore/Core.h
+++ b/src/CryptoNoteCore/Core.h
@@ -101,6 +101,7 @@ public:
   //ICoreInformation
   virtual size_t getPoolTransactionCount() const override;
   virtual size_t getBlockchainTransactionCount() const override;
+  virtual altChainList getAlternateChains() const override;
   virtual size_t getAlternativeBlockCount() const override;
   virtual uint64_t getTotalGeneratedAmount() const override;
   virtual std::vector<BlockTemplate> getAlternativeBlocks() const override;

--- a/src/CryptoNoteCore/DatabaseBlockchainCache.cpp
+++ b/src/CryptoNoteCore/DatabaseBlockchainCache.cpp
@@ -583,7 +583,7 @@ std::unique_ptr<IBlockchainCache> DatabaseBlockchainCache::split(uint32_t splitB
   cutTail(unitsCache, currentTop + 1 - splitBlockIndex);
 
   children.push_back(cache.get());
-  logger(Logging::TRACE) << "Delete successfull";
+  logger(Logging::TRACE) << "Delete successful";
 
   // invalidate top block index and hash
   topBlockIndex = boost::none;
@@ -1071,6 +1071,15 @@ uint64_t DatabaseBlockchainCache::getCachedTransactionsCount() const {
   }
 
   return *transactionsCount;
+}
+
+const Crypto::Hash& DatabaseBlockchainCache::getStartBlockHash() const {
+  if (!startBlockHash) {
+    auto batch = BlockchainReadBatch().requestCachedBlock(getStartBlockIndex());
+    auto result = readDatabase(batch);
+    startBlockHash = result.getCachedBlocks().at(getStartBlockIndex()).blockHash;
+  }
+  return *startBlockHash;
 }
 
 const Crypto::Hash& DatabaseBlockchainCache::getTopBlockHash() const {

--- a/src/CryptoNoteCore/DatabaseBlockchainCache.h
+++ b/src/CryptoNoteCore/DatabaseBlockchainCache.h
@@ -80,6 +80,7 @@ public:
                             std::vector<std::pair<Crypto::Hash, size_t>>& outputReferences) const override;
 
   uint32_t getTopBlockIndex() const override;
+  const Crypto::Hash& getStartBlockHash() const override;
   const Crypto::Hash& getTopBlockHash() const override;
   uint32_t getBlockCount() const override;
   bool hasBlock(const Crypto::Hash& blockHash) const override;
@@ -163,6 +164,7 @@ private:
   IDataBase& database;
   IBlockchainCacheFactory& blockchainCacheFactory;
   mutable boost::optional<uint32_t> topBlockIndex;
+  mutable boost::optional<Crypto::Hash> startBlockHash;
   mutable boost::optional<Crypto::Hash> topBlockHash;
   mutable boost::optional<uint64_t> transactionsCount;
   mutable boost::optional<uint32_t> keyOutputAmountsCount;

--- a/src/CryptoNoteCore/IBlockchainCache.h
+++ b/src/CryptoNoteCore/IBlockchainCache.h
@@ -112,6 +112,7 @@ public:
       std::function<ExtractOutputKeysResult(const CachedTransactionInfo& info, PackedOutIndex index, uint32_t globalIndex)> pred) const = 0;
 
   virtual uint32_t getTopBlockIndex() const = 0;
+  virtual const Crypto::Hash& getStartBlockHash() const = 0;
   virtual const Crypto::Hash& getTopBlockHash() const = 0;
   virtual uint32_t getBlockCount() const = 0;
   virtual bool hasBlock(const Crypto::Hash& blockHash) const = 0;

--- a/src/CryptoNoteCore/ICoreInformation.h
+++ b/src/CryptoNoteCore/ICoreInformation.h
@@ -20,12 +20,15 @@
 
 namespace CryptoNote {
 
+typedef std::list<std::pair<IBlockchainCache *, uint32_t>> altChainList;
+
 class ICoreInformation {
 public:
   virtual ~ICoreInformation() {}
 
   virtual size_t getPoolTransactionCount() const = 0;
   virtual size_t getBlockchainTransactionCount() const = 0;
+  virtual altChainList getAlternateChains() const = 0;
   virtual size_t getAlternativeBlockCount() const = 0;
   virtual uint64_t getTotalGeneratedAmount() const = 0;
   virtual std::vector<BlockTemplate> getAlternativeBlocks() const = 0;

--- a/src/Daemon/DaemonCommandsHandler.cpp
+++ b/src/Daemon/DaemonCommandsHandler.cpp
@@ -69,6 +69,7 @@ DaemonCommandsHandler::DaemonCommandsHandler(CryptoNote::Core& core, CryptoNote:
   m_consoleHandler.setHandler("print_pool", boost::bind(&DaemonCommandsHandler::print_pool, this, _1), "Print transaction pool (long format)");
   m_consoleHandler.setHandler("print_pool_sh", boost::bind(&DaemonCommandsHandler::print_pool_sh, this, _1), "Print transaction pool (short format)");
   m_consoleHandler.setHandler("set_log", boost::bind(&DaemonCommandsHandler::set_log, this, _1), "set_log <level> - Change current log level, <level> is a number 0-4");
+  m_consoleHandler.setHandler("alt_chain_info", boost::bind(&DaemonCommandsHandler::print_alternate_chains, this, _1), "alt_chain_info - Print information about alternative chains");
 }
 
 //--------------------------------------------------------------------------------
@@ -213,6 +214,36 @@ bool DaemonCommandsHandler::set_log(const std::vector<std::string>& args)
   }
 
   m_logManager.setMaxLevel(static_cast<Logging::Level>(l));
+  return true;
+}
+
+//--------------------------------------------------------------------------------
+bool DaemonCommandsHandler::print_alternate_chains(const std::vector<std::string>& args)
+{
+  CryptoNote::COMMAND_RPC_GET_ALTERNATE_CHAINS::request req;
+  CryptoNote::COMMAND_RPC_GET_ALTERNATE_CHAINS::response res;
+
+  if (args.size() != 0) {
+    std::cout << "Command 'alt_chain_info' doesn't take any arguments!" << std::endl;
+    return false;
+  }
+
+  if (!m_prpc_server->on_get_alternate_chains(req, res)) {
+    std::cout << res.status << std::endl;
+    return false;
+  }
+
+  if (res.chains.size() == 0)
+    std::cout << "No alternate chains found." << std::endl;
+  else {
+    std::cout << res.chains.size() << " alternate chains found:" << std::endl;
+
+    for (const auto& chain: res.chains) {
+      std::cout << chain.length << " blocks long, branching at height " << (chain.height - chain.length + 1)
+                << ", difficulty " << chain.difficulty << ": " << chain.block_hash;
+    }
+  }
+
   return true;
 }
 

--- a/src/Daemon/DaemonCommandsHandler.h
+++ b/src/Daemon/DaemonCommandsHandler.h
@@ -67,6 +67,7 @@ private:
   bool print_bc(const std::vector<std::string>& args);
   bool print_bci(const std::vector<std::string>& args);
   bool set_log(const std::vector<std::string>& args);
+  bool print_alternate_chains(const std::vector<std::string>& args);
   bool print_block(const std::vector<std::string>& args);
   bool print_tx(const std::vector<std::string>& args);
   bool print_pool(const std::vector<std::string>& args);

--- a/src/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/src/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -584,6 +584,34 @@ struct COMMAND_RPC_GET_BLOCK_HEADER_BY_HEIGHT {
   typedef BLOCK_HEADER_RESPONSE response;
 };
 
+struct COMMAND_RPC_GET_ALTERNATE_CHAINS {
+  typedef EMPTY_STRUCT request;
+
+  struct chain_info {
+    std::string block_hash;
+    uint32_t height;
+    uint32_t length;
+    Difficulty difficulty;
+
+    void serialize(ISerializer &s) {
+      KV_MEMBER(block_hash)
+      KV_MEMBER(height)
+      KV_MEMBER(length)
+      KV_MEMBER(difficulty)
+    }
+  };
+
+  struct response {
+    std::string status;
+    std::list<chain_info> chains;
+
+    void serialize(ISerializer &s) {
+      KV_MEMBER(status)
+      KV_MEMBER(chains)
+    }
+  };
+};
+
 struct F_COMMAND_RPC_GET_BLOCKS_LIST {
   struct request {
     uint64_t height;

--- a/src/Rpc/RpcServer.h
+++ b/src/Rpc/RpcServer.h
@@ -42,6 +42,7 @@ public:
   std::vector<std::string> getCorsDomains();
 
   bool on_get_block_headers_range(const COMMAND_RPC_GET_BLOCK_HEADERS_RANGE::request& req, COMMAND_RPC_GET_BLOCK_HEADERS_RANGE::response& res, JsonRpc::JsonRpcError& error_resp);
+  bool on_get_alternate_chains(const COMMAND_RPC_GET_ALTERNATE_CHAINS::request& req, COMMAND_RPC_GET_ALTERNATE_CHAINS::response& res);
 
 private:
 


### PR DESCRIPTION
Information about alternate chains is useful when deciding adequate number of checkpoints.