### PR TITLE
[Windows] Add noexcept(false) to destructor if it can throw an exception.

### DIFF
--- a/src/CryptoNoteCore/ICore.h
+++ b/src/CryptoNoteCore/ICore.h
@@ -37,8 +37,11 @@ enum class CoreEvent { POOL_UPDATED, BLOCKHAIN_UPDATED };
 
 class ICore {
 public:
-  virtual ~ICore() {
-  }
+#if defined(WIN32)
+  virtual ~ICore() noexcept(false) {}
+#else
+  virtual ~ICore() {}
+#endif
 
   virtual bool addMessageQueue(MessageQueue<BlockchainMessage>& messageQueue) = 0;
   virtual bool removeMessageQueue(MessageQueue<BlockchainMessage>& messageQueue) = 0;

--- a/src/CryptoNoteCore/ICoreInformation.h
+++ b/src/CryptoNoteCore/ICoreInformation.h
@@ -22,7 +22,11 @@ namespace CryptoNote {
 
 class ICoreInformation {
 public:
+#if defined(WIN32)
+  virtual ~ICoreInformation() noexcept(false) {}
+#else
   virtual ~ICoreInformation() {}
+#endif
 
   virtual size_t getPoolTransactionCount() const = 0;
   virtual size_t getBlockchainTransactionCount() const = 0;

--- a/src/crypto/hash.h
+++ b/src/crypto/hash.h
@@ -47,7 +47,11 @@ namespace Crypto {
   public:
 
     cn_context();
+#if defined(WIN32)
+    ~cn_context() noexcept(false);
+#else
     ~cn_context();
+#endif
 #if !defined(_MSC_VER) || _MSC_VER >= 1800
     cn_context(const cn_context &) = delete;
     void operator=(const cn_context &) = delete;

--- a/src/crypto/slow-hash.cpp
+++ b/src/crypto/slow-hash.cpp
@@ -45,7 +45,7 @@ namespace Crypto {
     }
   }
 
-  cn_context::~cn_context() {
+  cn_context::~cn_context() noexcept(false) {
     if (!VirtualFree(data, 0, MEM_RELEASE)) {
       throw bad_alloc();
     }


### PR DESCRIPTION
* Visual C++ 2015 changed the default value of noexcept() for destructors from false to true
* All its base classes and class that has destructor that can throw an exception must use noexcept(false) 