### PR TITLE
[gtest] Fix Test class destructor when compiling under Visual C++ 2015 or later

### DIFF
--- a/external/gtest/include/gtest/gtest.h
+++ b/external/gtest/include/gtest/gtest.h
@@ -354,7 +354,11 @@ class GTEST_API_ Test {
   typedef internal::TearDownTestCaseFunc TearDownTestCaseFunc;
 
   // The d'tor is virtual as we intend to inherit from Test.
+#if defined(WIN32)
+  virtual ~Test() noexcept(false);
+#else
   virtual ~Test();
+#endif
 
   // Sets up the stuff shared by all tests in this test case.
   //

--- a/external/gtest/src/gtest.cc
+++ b/external/gtest/src/gtest.cc
@@ -1893,7 +1893,12 @@ Test::Test()
 }
 
 // The d'tor restores the values of all Google Test flags.
-Test::~Test() {
+#if defined(WIN32)
+Test::~Test() noexcept(false)
+#else
+Test::~Test()
+#endif
+{
   delete gtest_flag_saver_;
 }
 


### PR DESCRIPTION
* add noexcept(false) to destructor