### PR TITLE
/get_generated_coins return alreadyGeneratedCoins

### DIFF
--- a/src/Rpc/CoreRpcServerCommandsDefinitions.h
+++ b/src/Rpc/CoreRpcServerCommandsDefinitions.h
@@ -880,4 +880,17 @@ struct COMMAND_RPC_GET_PEERSGRAY {
   };
 };
 
+struct COMMAND_RPC_GET_ISSUED_COINS {
+  typedef EMPTY_STRUCT request;
+
+  struct response {
+    std::string alreadyGeneratedCoins;
+    std::string status;
+
+    void serialize(ISerializer &s) {
+      KV_MEMBER(alreadyGeneratedCoins)
+      KV_MEMBER(status)
+    }
+  };
+};
 }

--- a/src/Rpc/RpcServer.cpp
+++ b/src/Rpc/RpcServer.cpp
@@ -131,6 +131,7 @@ std::unordered_map<std::string, RpcServer::RpcHandler<RpcServer::HandlerFunction
   { "/stop_daemon", { jsonMethod<COMMAND_RPC_STOP_DAEMON>(&RpcServer::on_stop_daemon), true } },
   { "/getpeers", { jsonMethod<COMMAND_RPC_GET_PEERS>(&RpcServer::on_get_peers), true } },
   { "/getpeersgray", { jsonMethod<COMMAND_RPC_GET_PEERSGRAY>(&RpcServer::on_get_peersgray), true } },
+  { "/get_generated_coins", { jsonMethod<COMMAND_RPC_GET_ISSUED_COINS>(&RpcServer::on_get_issued), true } },
 
   // json rpc
   { "/json_rpc", { std::bind(&RpcServer::processJsonRpcRequest, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3), true } }
@@ -481,6 +482,14 @@ bool RpcServer::on_get_height(const COMMAND_RPC_GET_HEIGHT::request& req, COMMAN
   res.network_height = std::max(static_cast<uint32_t>(1), m_protocol.getBlockchainHeight());
   res.status = CORE_RPC_STATUS_OK;
   return true;
+}
+
+bool RpcServer::on_get_issued(const COMMAND_RPC_GET_ISSUED_COINS::request& req, COMMAND_RPC_GET_ISSUED_COINS::response& res) {
+    Hash hash = m_core.getBlockHashByIndex(m_core.getTopBlockIndex());
+    BlockDetails blkDetails = m_core.getBlockDetails(hash);
+    res.alreadyGeneratedCoins = std::to_string(blkDetails.alreadyGeneratedCoins);
+    res.status = CORE_RPC_STATUS_OK;
+    return true;
 }
 
 bool RpcServer::on_get_transactions(const COMMAND_RPC_GET_TRANSACTIONS::request& req, COMMAND_RPC_GET_TRANSACTIONS::response& res) {

--- a/src/Rpc/RpcServer.h
+++ b/src/Rpc/RpcServer.h
@@ -81,6 +81,7 @@ private:
   bool on_stop_daemon(const COMMAND_RPC_STOP_DAEMON::request& req, COMMAND_RPC_STOP_DAEMON::response& res);
   bool on_get_peers(const COMMAND_RPC_GET_PEERS::request& req, COMMAND_RPC_GET_PEERS::response& res);
   bool on_get_peersgray(const COMMAND_RPC_GET_PEERSGRAY::request& req, COMMAND_RPC_GET_PEERSGRAY::response& res);
+  bool on_get_issued(const COMMAND_RPC_GET_ISSUED_COINS::request& req, COMMAND_RPC_GET_ISSUED_COINS::response& res);
 
   // json rpc
   bool on_getblockcount(const COMMAND_RPC_GETBLOCKCOUNT::request& req, COMMAND_RPC_GETBLOCKCOUNT::response& res);


### PR DESCRIPTION
This allows external websites to get current circulation with just 1 API call instead of 2 without the change.